### PR TITLE
multi config files & host fixup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3"
 
 services:
   server:
+    container_name: wireguard
+    restart: 'unless-stopped'
     image: wireguard
     build:
       context: .
@@ -10,7 +12,11 @@ services:
     volumes:
       - ./config:/etc/wireguard
       - /lib/modules:/lib/modules
-    network_mode: host
+#    network_mode: host #exposes all host ports to container
+#    expose:
+#     - 51820 #for linked container network_mode: 'service:<containername>
+    ports:
+      - 51820:51820/udp #docker default is tcp only
     cap_add:
       - NET_ADMIN
       - SYS_MODULE

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,20 +11,25 @@ if [ "$1" = "run-server" ]; then
     dkms install wireguard/$MODULE_VERSION
     modprobe wireguard
     
-    config=$(ls /etc/wireguard/*.conf | head -1)
-    if ip a | grep -q $(basename $config | cut -f 1 -d '.'); then
+    configs=/etc/wireguard/*.conf
+    for config in $configs
+    do
+     if ip a | grep -q $(basename $config | cut -f 1 -d '.'); then
         echo "Stopping existing interface"
         wg-quick down $config
-    fi
-
-    echo "Starting wireguard using $config"
-    wg-quick up $config
+     fi
+     echo "Starting wireguard using $config"
+     wg-quick up $config
+    done
     echo "Running config:"
     wg
 
     shutdown() {
         echo "Stopping wireguard"
-        wg-quick down $config
+        for config in $configs
+        do
+         wg-quick down $config
+        done
         rmmod wireguard
         echo "Uninstalling dkms module"
         dkms uninstall wireguard/$MODULE_VERSION


### PR DESCRIPTION
Hi,

i played a bit with this wireguard solution.
Had some trouble to implement multiple wireguard docker containers on one host and to change  your entrypoint script to provide multiple config files to get multiple wireguard interfaces.

network_mode: host exposes all ports to the container and linked containers.
the docker-compose now publish the port (udp)

i hope that works also for you :-) 
